### PR TITLE
Add support for Git external sources

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -79,7 +79,7 @@ jobs:
         env:
           SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: "1"
         with:
-          snapcraft-channel: latest/edge
+          snapcraft-channel: latest/stable
           snapcraft-args: --verbose
       - name: upload snap to workflow artifacts
         id: upload-artifact

--- a/docs/external-sources.md
+++ b/docs/external-sources.md
@@ -20,6 +20,7 @@ The Git external source clones a Git repository and optionally checks out a spec
     "sourceType": "git",
     "repository": "https://github.com/canonical/dotnet-test-runner",
     "commitish": "v1.2.0",
+    "rootDirectory": "src/main",
     "postClone": [
         "make GIT_COMMIT_ID",
         "make GIT_TAG_VERSION"
@@ -39,6 +40,7 @@ The Git external source clones a Git repository and optionally checks out a spec
 | `sourceType` | string | **Yes** | The type of external source. Must be `"git"` for Git repositories. |
 | `repository` | string | **Yes** | The URL of the Git repository to clone. Supports HTTPS and SSH URLs. |
 | `commitish` | string | No | A commit SHA, tag, or branch name to check out after cloning. If omitted, the default branch is used. |
+| `rootDirectory` | string | No | A relative path to a subdirectory within the repository to use as the source root. Only this subdirectory will be copied to the destination. |
 | `postClone` | array of strings | No | Shell commands to execute after cloning and checking out. Runs in the cloned repository directory. |
 | `ignoredFiles` | array of strings | No | Relative paths of files or directories to delete from the cloned repository before copying to the build directory. |
 
@@ -78,6 +80,41 @@ If omitted, the repository's default branch (typically `main` or `master`) is us
 "commitish": "v1.2.0"
 "commitish": "7a9f3e2b4c1d"
 "commitish": "main"
+```
+
+##### `rootDirectory` (Optional)
+
+A relative path to a subdirectory within the cloned repository. When specified, only the contents of this subdirectory will be copied to the destination build directory, rather than the entire repository.
+
+This is useful when:
+- The repository contains multiple projects or packages, and you only need one
+- The actual source code is nested within subdirectories
+- You want to exclude top-level configuration or documentation files
+
+The path is relative to the repository root and should use forward slashes (`/`) as path separators, even on Windows.
+
+**Important notes:**
+- The directory must exist in the cloned repository, or an error (FL0052) will be raised
+- The `ignoredFiles` paths are relative to the repository root, not the `rootDirectory`
+- Post-clone commands run in the repository root, before the `rootDirectory` is applied
+
+**Examples:**
+```json
+"rootDirectory": "src"
+"rootDirectory": "packages/core"
+"rootDirectory": "modules/main/source"
+```
+
+**Example use case:**
+```json
+{
+    "repository": "https://github.com/example/monorepo",
+    "rootDirectory": "packages/cli",
+    "ignoredFiles": [
+        "packages/web/",
+        "packages/mobile/"
+    ]
+}
 ```
 
 ##### `postClone` (Optional)
@@ -238,7 +275,27 @@ The following errors can occur during external source processing:
 
 ---
 
-#### FL0052: Post-clone command failed
+#### FL0052: Root directory not found
+
+**Cause**: The directory specified in `rootDirectory` does not exist in the cloned repository.
+
+**Example:**
+```json
+{
+    "repository": "https://github.com/user/repo",
+    "rootDirectory": "src/non-existent"  // Directory doesn't exist
+}
+```
+
+**Resolution**:
+- Verify the path is correct and exists in the repository
+- Check for typos in the directory name (paths are case-sensitive on Linux/macOS)
+- Ensure the directory exists in the specific commit/tag/branch you're checking out
+- Clone the repository manually and verify the directory structure
+
+---
+
+#### FL0053: Post-clone command failed
 
 **Cause**: A command specified in `postClone` exited with a non-zero status code.
 
@@ -256,7 +313,7 @@ The following errors can occur during external source processing:
 
 ---
 
-#### FL0053: Deletion of ignored file failed
+#### FL0054: Deletion of ignored file failed
 
 **Cause**: Failed to delete a file or directory specified in `ignoredFiles`.
 
@@ -340,6 +397,7 @@ Here's a complete example demonstrating all features:
     "sourceType": "git",
     "repository": "https://github.com/canonical/dotnet-test-runner",
     "commitish": "v1.2.0",
+    "rootDirectory": "src",
     "postClone": [
         "make GIT_COMMIT_ID",
         "make GIT_TAG_VERSION",
@@ -363,10 +421,11 @@ Here's a complete example demonstrating all features:
 3. Execute `make GIT_COMMIT_ID` to generate version information
 4. Execute `make GIT_TAG_VERSION` to embed the tag version
 5. Make all shell scripts in `scripts/` executable
-6. Delete Git metadata, CI config, tests, documentation, and editor config
+6. Delete Git metadata, CI config, tests, documentation, and editor config from the repository root
 7. Remove the `.git` directory
-8. Cache the processed result for future use
-9. Copy the final result to the destination directory
+8. Use only the `src` subdirectory as the source (instead of the entire repository)
+9. Cache the processed result for future use
+10. Copy the final result to the destination directory
 
 ## Future Enhancements
 

--- a/docs/external-sources.md
+++ b/docs/external-sources.md
@@ -1,0 +1,380 @@
+# External Sources Documentation
+
+External sources allow Flamenco to incorporate code from external repositories into your package builds. This is useful when you need to include third-party dependencies, submodules, or other external code that isn't part of your main source tree.
+
+## Overview
+
+The external sources system downloads and prepares external code before building your package. Each external source is defined in a JSON descriptor file that specifies where to obtain the code and how to prepare it.
+
+## Supported Source Types
+
+### Git External Source
+
+The Git external source clones a Git repository and optionally checks out a specific commit, tag, or branch.
+
+#### JSON Example
+
+```json
+{
+    "type": "external_source",
+    "sourceType": "git",
+    "repository": "https://github.com/canonical/dotnet-test-runner",
+    "commitish": "v1.2.0",
+    "postClone": [
+        "make GIT_COMMIT_ID",
+        "make GIT_TAG_VERSION"
+    ],
+    "ignoredFiles": [
+        ".gitignore",
+        ".github/workflows/build.yml"
+    ]
+}
+```
+
+#### Field Reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | No | Descriptor file type identifier. Can be `"external_source"` or omitted. |
+| `sourceType` | string | **Yes** | The type of external source. Must be `"git"` for Git repositories. |
+| `repository` | string | **Yes** | The URL of the Git repository to clone. Supports HTTPS and SSH URLs. |
+| `commitish` | string | No | A commit SHA, tag, or branch name to check out after cloning. If omitted, the default branch is used. |
+| `postClone` | array of strings | No | Shell commands to execute after cloning and checking out. Runs in the cloned repository directory. |
+| `ignoredFiles` | array of strings | No | Relative paths of files or directories to delete from the cloned repository before copying to the build directory. |
+
+#### Field Details
+
+##### `sourceType` (Required)
+
+Specifies the type of external source. Use `"git"` for Git external sources.
+
+**Example:**
+```json
+"sourceType": "git"
+```
+
+##### `repository` (Required)
+
+The URL of the Git repository to clone. This can be any URL format supported by Git, including HTTPS and SSH.
+
+**Examples:**
+```json
+"repository": "https://github.com/username/repo.git"
+"repository": "https://gitlab.com/group/project.git"
+"repository": "git@github.com:username/repo.git"
+```
+
+##### `commitish` (Optional)
+
+A Git reference to check out after cloning. This can be:
+- A commit SHA (full or abbreviated): `"7a9f3e2b"`
+- A tag: `"v1.2.0"`, `"release-2023-12"`
+- A branch name: `"main"`, `"develop"`, `"feature/new-api"`
+
+If omitted, the repository's default branch (typically `main` or `master`) is used.
+
+**Examples:**
+```json
+"commitish": "v1.2.0"
+"commitish": "7a9f3e2b4c1d"
+"commitish": "main"
+```
+
+##### `postClone` (Optional)
+
+An array of shell commands to execute after the repository has been cloned and checked out. Commands are executed sequentially using `/usr/bin/env sh -c`, which provides a portable shell environment.
+
+Commands run in the context of the cloned repository directory. If any command exits with a non-zero status code, the process fails immediately and subsequent commands are not executed.
+
+**Common use cases:**
+- Generate version information: `"make GIT_COMMIT_ID"`
+- Build generated files: `"./configure && make"`
+- Download dependencies: `"npm install --production"`
+- Prepare source files: `"python setup.py build"`
+
+**Example:**
+```json
+"postClone": [
+    "chmod +x build.sh",
+    "./build.sh --prepare",
+    "make VERSION_FILE"
+]
+```
+
+##### `ignoredFiles` (Optional)
+
+An array of relative file or directory paths to delete from the cloned repository before it's copied to the build directory. This is useful for removing files or directories that shouldn't be included in the package, such as CI configuration, documentation, or test files.
+
+Paths are relative to the repository root. Both files and directories are supported:
+- **Files**: Individual files are deleted
+- **Directories**: Entire directories and their contents are deleted recursively
+
+If a specified path doesn't exist (neither as a file nor directory), it is silently ignored (similar to how `.gitignore` works).
+
+**Common use cases:**
+- Remove CI configuration: `".github/workflows/build.yml"`, `".github/"`
+- Remove Git metadata: `".gitignore"`, `".gitattributes"`
+- Remove documentation: `"docs/"`, `"README.md"`
+- Remove test files: `"tests/"`, `"*.test.js"`
+
+**Example:**
+```json
+"ignoredFiles": [
+    ".gitignore",
+    ".github/workflows/build.yml",
+    "tests/",
+    "docs/README.md"
+]
+```
+
+## Error Reference
+
+The following errors can occur during external source processing:
+
+### General External Sources errors
+
+#### FL0043: Unsupported external source type
+
+**Cause**: The `sourceType` field contains a value other than `"git"`.
+
+**Example:**
+```json
+"sourceType": "svn"  // Not supported
+```
+
+**Resolution**: Use `"git"` as the source type, or wait for additional source types to be implemented.
+
+---
+
+#### FL0044: Unspecified external source type
+
+**Cause**: The `sourceType` field is missing from the descriptor file.
+
+**Example:**
+```json
+{
+    "type": "external_source",
+    "repository": "https://github.com/user/repo"
+    // Missing "sourceType" field
+}
+```
+
+**Resolution**: Add the `sourceType` field with the value `"git"`.
+
+---
+
+#### FL0045: Invalid git external source descriptor
+
+**Cause**: Required fields are missing or invalid in the Git external source descriptor.
+
+**Common causes:**
+- Missing `repository` field
+- Invalid JSON structure
+- Incorrect field types (e.g., string instead of array)
+
+**Example of invalid descriptor:**
+```json
+{
+    "sourceType": "git"
+    // Missing required "repository" field
+}
+```
+
+**Resolution**: Ensure all required fields are present and have the correct types. The error metadata will indicate which fields are invalid.
+
+---
+
+#### Operation Canceled
+
+**Cause**: The operation was canceled via the `CancellationToken`.
+
+**Common causes:**
+- User-initiated cancellation
+- Timeout
+- Application shutdown
+
+**Resolution**: This is typically an expected behavior when operations are intentionally canceled. No action is usually required.
+
+---
+
+### Git External Sources errors
+
+#### FL0050: Git clone failed
+
+**Cause**: The Git clone or checkout operation failed.
+
+**Common causes:**
+- Invalid repository URL
+- Network connectivity issues
+- Authentication failure (for private repositories)
+- Invalid `commitish` (commit, tag, or branch doesn't exist)
+- Insufficient disk space
+- Permission issues with the cache directory
+
+**Resolution**: 
+- Verify the repository URL is correct and accessible
+- Check network connectivity
+- For private repositories, ensure proper authentication is configured
+- Verify the `commitish` exists in the repository
+- Ensure sufficient disk space and write permissions
+
+---
+
+#### FL0051: Repository copy from cache failed
+
+**Cause**: Failed to copy the cached repository to the destination directory.
+
+**Common causes:**
+- Insufficient disk space
+- Permission issues with the destination directory
+- Destination directory is locked by another process
+- Filesystem errors
+
+**Resolution**:
+- Ensure sufficient disk space is available
+- Verify write permissions on the destination directory
+- Check for filesystem errors
+- Ensure no other process is locking the destination
+
+---
+
+#### FL0052: Post-clone command failed
+
+**Cause**: A command specified in `postClone` exited with a non-zero status code.
+
+**Example:**
+```json
+"postClone": ["make build"]  // Exits with code 2
+```
+
+**Resolution**:
+- Check the command syntax and ensure it's valid
+- Verify all dependencies required by the command are available
+- Test the command manually in a cloned repository
+- Review command output for specific error messages
+- Ensure the command is appropriate for the shell environment (`/usr/bin/env sh -c`)
+
+---
+
+#### FL0053: Deletion of ignored file failed
+
+**Cause**: Failed to delete a file or directory specified in `ignoredFiles`.
+
+**Common causes:**
+- File or directory is read-only or immutable
+- Permission issues
+- File is locked by another process
+- Directory contains locked files
+- Filesystem errors
+
+**Resolution**:
+- Check file/directory permissions
+- Ensure no other process is using the file or files within the directory
+- Verify filesystem integrity
+- Consider removing the path from `ignoredFiles` if it's not critical
+
+## Best Practices
+
+### 1. Pin to Specific Versions
+
+Always use a specific commit SHA or tag in the `commitish` field for reproducible builds:
+
+```json
+"commitish": "v1.2.0"  // Good: specific tag
+"commitish": "main"    // Avoid: branch tip can change
+```
+
+### 2. Minimize Post-Clone Commands
+
+Keep post-clone commands simple and fast. Complex build processes should be deferred to the main build phase:
+
+```json
+// Good: Simple preparation tasks
+"postClone": [
+    "make generate-version",
+    "chmod +x build.sh"
+]
+
+// Avoid: Long-running builds
+"postClone": [
+    "npm install && npm run build && npm test"  // Too much work
+]
+```
+
+### 3. Clean Up Unnecessary Files
+
+Use `ignoredFiles` to remove files that bloat the source package:
+
+```json
+"ignoredFiles": [
+    ".git",
+    ".github/",
+    "tests/",
+    "docs/",
+    ".gitignore",
+    ".gitattributes",
+    "*.test.js"
+]
+```
+
+### 4. Use HTTPS for Public Repositories
+
+For public repositories, prefer HTTPS URLs for better compatibility:
+
+```json
+"repository": "https://github.com/user/repo.git"  // Preferred
+"repository": "git@github.com:user/repo.git"     // Requires SSH keys
+```
+
+### 5. Test Commands Independently
+
+Before adding commands to `postClone`, test them manually in a cloned repository to ensure they work as expected.
+
+## Example: Complete Workflow
+
+Here's a complete example demonstrating all features:
+
+```json
+{
+    "type": "external_source",
+    "sourceType": "git",
+    "repository": "https://github.com/canonical/dotnet-test-runner",
+    "commitish": "v1.2.0",
+    "postClone": [
+        "make GIT_COMMIT_ID",
+        "make GIT_TAG_VERSION",
+        "chmod +x scripts/*.sh"
+    ],
+    "ignoredFiles": [
+        ".gitignore",
+        ".gitattributes",
+        ".github/",
+        "tests/",
+        "docs/",
+        "*.md",
+        ".editorconfig"
+    ]
+}
+```
+
+**This configuration will:**
+1. Clone the `dotnet-test-runner` repository
+2. Check out the `v1.2.0` tag
+3. Execute `make GIT_COMMIT_ID` to generate version information
+4. Execute `make GIT_TAG_VERSION` to embed the tag version
+5. Make all shell scripts in `scripts/` executable
+6. Delete Git metadata, CI config, tests, documentation, and editor config
+7. Remove the `.git` directory
+8. Cache the processed result for future use
+9. Copy the final result to the destination directory
+
+## Future Enhancements
+
+The external sources system is designed to be extensible. Potential future source types include:
+
+- **HTTP/HTTPS**: Download and extract tarballs or zip files
+- **Bazaar**: Support for Bazaar repositories
+- **Subversion**: Support for SVN repositories
+- **Mercurial**: Support for Mercurial repositories
+- **Local**: Copy from a local directory
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,7 +62,6 @@ parts:
       - dpkg-dev
       - fakeroot
       - gcc
-      - tar
       - xz-utils
     override-build: |
       # needed by dpkg-genbuildinfo:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -69,6 +69,12 @@ parts:
       cp --recursive /etc/dpkg "$CRAFT_PART_INSTALL"/etc
       cp /var/lib/dpkg/status "$CRAFT_PART_INSTALL"/var/lib/dpkg/
 
+  git-external-source-dependencies:
+    plugin: nil
+    stage-packages:
+      - git
+      - make
+
 layout:
   /etc/dpkg:
     bind: $SNAP_COMMON/dpkg

--- a/src/Flamenco.Console/Log.cs
+++ b/src/Flamenco.Console/Log.cs
@@ -6,7 +6,7 @@ namespace Flamenco.Console;
 public static class Log
 {
     private static void Print(string prefix, string message) => System.Console.WriteLine(string.Concat(prefix, message));
-    
+
     private static void Print(string prefix, string message, ConsoleColor textColor)
     {
         System.Console.ForegroundColor = textColor;
@@ -24,12 +24,12 @@ public static class Log
     {
         Annotations(result.Annotations, 0);
     }
-    
+
     public static void Annotations(ImmutableList<IAnnotation> annotations, int offset)
     {
         const int tabSize = 5;
-        
-        foreach (var annotation in annotations)    
+
+        foreach (var annotation in annotations)
         {
             var message = new StringBuilder();
             message.Append(' ', tabSize * offset).Append(annotation.Severity.ToString()).Append(' ').Append(annotation.Identifier).Append(": ").AppendLine(annotation.Title);
@@ -45,6 +45,12 @@ public static class Log
             {
                 message.AppendLine();
                 message.Append(' ', 2 + tabSize * offset).AppendLine(annotation.Description);
+            }
+
+            foreach (var item in annotation.Metadata)
+            {
+                message.Append(' ', 4 + tabSize * offset).Append(item.Key).Append(": ")
+                    .AppendLine(item.Value?.ToString());
             }
 
             if (annotation is ExceptionalAnnotation exceptionalAnnotation)
@@ -76,6 +82,6 @@ public static class Log
             }
 
             Annotations(annotation.InnerAnnotations, offset + 1);
-        }        
+        }
     }
 }

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -19,6 +19,11 @@ public class DebianSourcePackageBuilder
 {
     private const string FlamencoFileName = "flamenco.json";
 
+    private const int FileNotSpecificToCurrentBuildTarget = -1;
+    private const int FileNotSpecificToASourcePackageOrSeries = 0;
+    private const int FileSpecificToEitherSourcePackageOrSeries = 1;
+    private const int FileSpecificToBothSourcePackageAndSeries = 2;
+
     public required BuildTarget BuildTarget { get; set; }
 
     public required SourceDirectoryInfo SourceDirectory { get; set; }
@@ -277,7 +282,7 @@ public class DebianSourcePackageBuilder
                         if (fileContext.BuildTargetSpecificity > otherFile.BuildTargetSpecificity)
                         {
                             destinationFiles[fileContext.FileName] = (
-                                new FlamencoFileInfo(fileContext.FlamencoFile, file),
+                                new FlamencoFileInfo(fileContext.IsFlamencoFile, file),
                                 fileContext.BuildTargetSpecificity);
                         }
                         else if (fileContext.BuildTargetSpecificity == otherFile.BuildTargetSpecificity)
@@ -290,7 +295,7 @@ public class DebianSourcePackageBuilder
                     else
                     {
                         destinationFiles[fileContext.FileName] = (
-                            new FlamencoFileInfo(fileContext.FlamencoFile, file),
+                            new FlamencoFileInfo(fileContext.IsFlamencoFile, file),
                             fileContext.BuildTargetSpecificity);
                     }
 
@@ -305,7 +310,7 @@ public class DebianSourcePackageBuilder
                 elementSelector: e => e.Value.Info));
     }
 
-    private Result<(string FileName, bool FlamencoFile, int BuildTargetSpecificity)> AnalyzeFileExtension(FileInfo file)
+    private Result<(string FileName, bool IsFlamencoFile, int BuildTargetSpecificity)> AnalyzeFileExtension(FileInfo file)
     {
         var result = new Result();
 
@@ -314,10 +319,11 @@ public class DebianSourcePackageBuilder
 
         if (fileExtensions.Length < 2)
         {
-            return result.WithValue((file.Name, FlamencoFile: false, BuildTargetSpecificity: 0));
+            return result.WithValue((file.Name, IsFlamencoFile: false,
+                BuildTargetSpecificity: FileNotSpecificToASourcePackageOrSeries));
         }
 
-        bool flamencoFile = false;
+        bool isFlamencoFile;
         bool matchesTarget = true;
         bool packageNameIsDefined = false;
         bool seriesNameIsDefined = false;
@@ -344,8 +350,9 @@ public class DebianSourcePackageBuilder
             }
             else
             {
-                flamencoFile = file.Name.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
-                return result.WithValue((file.Name, flamencoFile, BuildTargetSpecificity: 0));
+                isFlamencoFile = file.Name.Equals(FlamencoFileName, StringComparison.OrdinalIgnoreCase);
+                return result.WithValue((file.Name, isFlamencoFile,
+                    BuildTargetSpecificity: FileNotSpecificToASourcePackageOrSeries));
             }
         }
 
@@ -384,27 +391,22 @@ public class DebianSourcePackageBuilder
 
         string fileName = file.Name.Substring(startIndex: 0, length: file.Name.Length - totalExtensionLength);
 
-        flamencoFile = fileName.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
+        isFlamencoFile = fileName.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
 
-        // A specificity score that determines how specific a file is to a source package or series.
-        // A specificity of -1 means that the file is not specific to current build target.
-        // A specificity of 0 means that the file is not specific to a source package or series.
-        // A specificity of 1 means that the file is specific to either a source package or a series.
-        // A specificity of 2 means that the file is specific to both a source package and a series.
         if (!matchesTarget)
         {
-            buildTargetSpecificity = -1;
+            buildTargetSpecificity = FileNotSpecificToCurrentBuildTarget;
         }
         else if (packageNameIsDefined && seriesNameIsDefined)
         {
-            buildTargetSpecificity = 2;
+            buildTargetSpecificity = FileSpecificToBothSourcePackageAndSeries;
         }
         else
         {
-            buildTargetSpecificity = 1;
+            buildTargetSpecificity = FileSpecificToEitherSourcePackageOrSeries;
         }
 
-        return result.WithValue((fileName, flamencoFile, buildTargetSpecificity));
+        return result.WithValue((fileName, isFlamencoFile, buildTargetSpecificity));
     }
 
     private async Task<Result> CopySourceFilesToDestinationDirectoryAsync(
@@ -497,7 +499,7 @@ public class DebianSourcePackageBuilder
             {
                 if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
 
-                if (fileInfo.FlamencoFile)
+                if (fileInfo.IsFlamencoFile)
                 {
                     result = result.Merge(await HandleFlamencoFile(fileInfo, destinationDirectory, cancellationToken));
                 }

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -526,13 +526,15 @@ public class DebianSourcePackageBuilder
         switch (type)
         {
             case "external_source":
+                var cacheDirectory = Directory.CreateDirectory(Path.Combine(DestinationDirectory.FullName, "cache"));
+
                 var externalSourceResult = ExternalSources.ExternalSourceBase.Parse(jsonNode!);
 
                 if (externalSourceResult.IsFailure)
                     return result.Merge(externalSourceResult);
 
                 var downloadResult =
-                    await externalSourceResult.Value.Download(destinationDirectory.FullName, cancellationToken);
+                    await externalSourceResult.Value.Download(destinationDirectory, cacheDirectory, cancellationToken);
 
                 return result.Merge(downloadResult);
             default:

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -10,6 +10,7 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Flamenco.Packaging.Dpkg;
 
@@ -391,7 +392,7 @@ public class DebianSourcePackageBuilder
 
         string fileName = file.Name.Substring(startIndex: 0, length: file.Name.Length - totalExtensionLength);
 
-        isFlamencoFile = fileName.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
+        isFlamencoFile = fileName.Equals(FlamencoFileName, StringComparison.OrdinalIgnoreCase);
 
         if (!matchesTarget)
         {
@@ -519,7 +520,16 @@ public class DebianSourcePackageBuilder
     {
         var result = Result.Success;
 
-        var jsonNode = JsonNode.Parse(await File.ReadAllTextAsync(fileInfo.FileInfo.FullName, cancellationToken));
+        var jsonNode = default(JsonNode);
+
+        try
+        {
+            JsonNode.Parse(await File.ReadAllTextAsync(fileInfo.FileInfo.FullName, cancellationToken));
+        }
+        catch (JsonException ex)
+        {
+            return result.WithAnnotation(new InvalidFlamencoFileContent(fileInfo.FileInfo.FullName, ex));
+        }
 
         var type = jsonNode?["type"]?.GetValue<string>();
 
@@ -759,5 +769,16 @@ public class DebianSourcePackageBuilder
             locations: ImmutableList.Create(new Location { ResourceLocator = filePath }))
     {
     }
-}
 
+    public class InvalidFlamencoFileContent(
+        string filePath,
+        Exception exception)
+        : ErrorBase(
+            identifier: "FL0042",
+            title: "Invalid Flamenco file content",
+            message: $"The Flamenco file '{filePath}' has invalid content",
+            locations: ImmutableList.Create(new Location { ResourceLocator = filePath }),
+            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)))
+    {
+    }
+}

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -524,25 +524,20 @@ public class DebianSourcePackageBuilder
         switch (type)
         {
             case "external_source":
-                try
-                {
-                    var externalSource = ExternalSources.ExternalSourceBase.Create(fileInfo.FileInfo);
-                    await externalSource.Download(destinationDirectory.FullName, cancellationToken);
-                }
-                catch (Exception e)
-                {
-                    return new CouldNotCreateFlamencoFileDescriptor(
-                        filePath: fileInfo.FileInfo.FullName,
-                        exception: e);
-                }
-                break;
+                var externalSourceResult = ExternalSources.ExternalSourceBase.Create(jsonNode!);
+
+                if (externalSourceResult.IsFailure)
+                    return result.Merge(externalSourceResult);
+
+                var downloadResult =
+                    await externalSourceResult.Value.Download(destinationDirectory.FullName, cancellationToken);
+
+                return result.Merge(downloadResult);
             default:
                 return result.WithAnnotation(new InvalidFlamencoFileType(
                     filePath: fileInfo.FileInfo.FullName,
                     type: type));
         }
-
-        return result;
     }
 
     private bool IsPatchesDirectory(DirectoryInfo directory)
@@ -758,18 +753,6 @@ public class DebianSourcePackageBuilder
             title: "Invalid Flamenco file type",
             message: $"The Flamenco file '{filePath}' has an invalid or unsupported type '{type ?? "null"}'",
             locations: ImmutableList.Create(new Location { ResourceLocator = filePath }))
-    {
-    }
-
-    public class CouldNotCreateFlamencoFileDescriptor(
-        string filePath,
-        Exception exception)
-        : ErrorBase(
-            identifier: "FL0042",
-            title: "Could not create Flamenco file descriptor",
-            message: $"Could not create Flamenco file descriptor from file.",
-            locations: ImmutableList.Create(new Location { ResourceLocator = filePath }),
-            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)))
     {
     }
 }

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -524,8 +524,17 @@ public class DebianSourcePackageBuilder
         switch (type)
         {
             case "external_source":
-                var externalSource = ExternalSources.ExternalSourceBase.Create(fileInfo.FileInfo);
-                await externalSource.Download(destinationDirectory.FullName, cancellationToken);
+                try
+                {
+                    var externalSource = ExternalSources.ExternalSourceBase.Create(fileInfo.FileInfo);
+                    await externalSource.Download(destinationDirectory.FullName, cancellationToken);
+                }
+                catch (Exception e)
+                {
+                    return new CouldNotCreateFlamencoFileDescriptor(
+                        filePath: fileInfo.FileInfo.FullName,
+                        exception: e);
+                }
                 break;
             default:
                 return result.WithAnnotation(new InvalidFlamencoFileType(
@@ -749,6 +758,18 @@ public class DebianSourcePackageBuilder
             title: "Invalid Flamenco file type",
             message: $"The Flamenco file '{filePath}' has an invalid or unsupported type '{type ?? "null"}'",
             locations: ImmutableList.Create(new Location { ResourceLocator = filePath }))
+    {
+    }
+
+    public class CouldNotCreateFlamencoFileDescriptor(
+        string filePath,
+        Exception exception)
+        : ErrorBase(
+            identifier: "FL0042",
+            title: "Could not create Flamenco file descriptor",
+            message: $"Could not create Flamenco file descriptor from file.",
+            locations: ImmutableList.Create(new Location { ResourceLocator = filePath }),
+            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)))
     {
     }
 }

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -526,7 +526,7 @@ public class DebianSourcePackageBuilder
         switch (type)
         {
             case "external_source":
-                var externalSourceResult = ExternalSources.ExternalSourceBase.Create(jsonNode!);
+                var externalSourceResult = ExternalSources.ExternalSourceBase.Parse(jsonNode!);
 
                 if (externalSourceResult.IsFailure)
                     return result.Merge(externalSourceResult);

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -422,6 +422,7 @@ public class DebianSourcePackageBuilder
         {
             if (!sourceFileIndex.TryGetValue("series", out var seriesFile))
             {
+                if (destinationDirectory.Exists) destinationDirectory.Delete();
                 return result.WithAnnotation(new CouldNotFindPatchesSeriesFile(BuildTarget));
             }
 
@@ -712,10 +713,13 @@ public class DebianSourcePackageBuilder
 
     public class CouldNotFindPatchesSeriesFile(
         BuildTarget buildTarget)
-        : ErrorBase(
+        : AnnotationBase(
             identifier: "FL0038",
             title: "Could not find a patches/series file for build target",
-            message: $"Could not find a patches/series file for build target {buildTarget}",
+            message: $"Could not find a patches/series file for build target {buildTarget}. Building a source " +
+                     $"package that carries no patches.",
+            severity: AnnotationSeverity.Warning,
+            warningLevel: WarningLevels.MajorWarning,
             metadata: ImmutableDictionary<string, object?>.Empty
                 .Add(nameof(BuildTarget), buildTarget))
     {

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -10,34 +10,36 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Text;
+using System.Text.Json.Nodes;
 using Flamenco.Packaging.Dpkg;
 
 namespace Flamenco.Packaging;
 
 public class DebianSourcePackageBuilder
 {
+    private const string FlamencoFileName = "flamenco.json";
+
     public required BuildTarget BuildTarget { get; set; }
-    
+
     public required SourceDirectoryInfo SourceDirectory { get; set; }
-    
+
     public required DirectoryInfo DestinationDirectory { get; set; }
-    
+
     public required TarballCompressionMethod TarballCompressionMethod { get; set; }
-    
+
     public required ITarArchivingServiceProvider TarArchivingServiceProvider { get; set; }
-    
+
     public required BuildOutput BuildOutput { get; set; }
-    
+
     public async ValueTask<Result> BuildDebianSourcePackageAsync(CancellationToken cancellationToken = default)
     {
         var result = new Result();
-        var readFirstChangelogEntryResult = 
+        var readFirstChangelogEntryResult =
             await SourceDirectory.ReadFirstChangelogEntryAsync(BuildTarget, cancellationToken).ConfigureAwait(false);
         result = result.Merge(readFirstChangelogEntryResult);
         if (readFirstChangelogEntryResult.IsFailure) return result;
         var changelogEntry = readFirstChangelogEntryResult.Value;
-            
+
         if (changelogEntry.PackageName.Identifier != BuildTarget.PackageName)
         {
             result = result.WithAnnotation(new ChangelogFileNameAndContentMismatch(
@@ -68,7 +70,7 @@ public class DebianSourcePackageBuilder
                     buildTarget: BuildTarget,
                     distributions: changelogEntry.Distributions,
                     location: changelogEntry.Location));
-                
+
                 if (!changelogEntry.Distributions.Any(series => series.Series.Identifier == BuildTarget.SeriesName))
                 {
                     result = result.WithAnnotation(new ChangelogFileNameAndContentMismatch(
@@ -78,17 +80,17 @@ public class DebianSourcePackageBuilder
                 }
                 break;
         }
-        
+
         var destinationDebianDirectory = new DirectoryInfo(Path.Combine(
             DestinationDirectory.FullName,
-            $"{BuildTarget.PackageName}-{changelogEntry.Version}", 
+            $"{BuildTarget.PackageName}-{changelogEntry.Version}",
             "debian"));
 
         var origTarball = new FileInfo(Path.Combine(
             DestinationDirectory.FullName,
             $"{changelogEntry.PackageName}_{changelogEntry.Version.UpstreamVersion}" +
             $".orig.tar{TarballCompressionMethod.FileExtension()}"));
-        
+
         return await result
             .Then(() => CheckOrigTarballExists(origTarball))
             .Then(() => RecursivelyCopyMatchingFilesAsync(
@@ -109,13 +111,13 @@ public class DebianSourcePackageBuilder
     private Result CheckOrigTarballExists(FileInfo origTarball)
     {
         var result = Result.Success;
-        
+
         if (BuildOutput != BuildOutput.DebianDirectoryOnly && !origTarball.Exists)
         {
             return result.WithAnnotation(new OrigTarballNotFound(
                 BuildTarget, new Location { ResourceLocator = origTarball.FullName }));
         }
-        
+
         return result;
     }
 
@@ -133,15 +135,15 @@ public class DebianSourcePackageBuilder
     };
 
     private async Task<Result> RunDpkgBuildPackageAsync(
-        DirectoryInfo sourceTreeDirectory, 
-        BuildTarget buildTarget, 
+        DirectoryInfo sourceTreeDirectory,
+        BuildTarget buildTarget,
         CancellationToken cancellationToken)
     {
         if (BuildOutput is BuildOutput.DebianDirectoryOnly or BuildOutput.DebianSourceTreeOnly)
         {
             return Result.Success;
         }
-        
+
         try
         {
             var origTarballInclusionArgument = BuildOutput switch
@@ -150,15 +152,15 @@ public class DebianSourcePackageBuilder
                 BuildOutput.SourcePackageExcludingOrigTarball => "-sd",
                 _ => throw new UnreachableException($"The build output type '{BuildOutput}' is not supported.")
             };
-            
+
             var dpkgBuildPackage = new Process()
             {
                 StartInfo = new ProcessStartInfo(
                     fileName: "/usr/bin/env",
                     arguments: [
-                        "dpkg-buildpackage", 
+                        "dpkg-buildpackage",
                         "--build=source",
-                        "--no-pre-clean", 
+                        "--no-pre-clean",
                         "--no-check-builddeps",
                         origTarballInclusionArgument,
                     ])
@@ -176,8 +178,8 @@ public class DebianSourcePackageBuilder
             {
                 return new Result().WithAnnotation(
                     new DpkgBuildPackageFailed(
-                        buildTarget: buildTarget, 
-                        location: new Location { ResourceLocator = sourceTreeDirectory.FullName }, 
+                        buildTarget: buildTarget,
+                        location: new Location { ResourceLocator = sourceTreeDirectory.FullName },
                         reason: $"Exit code '{dpkgBuildPackage.ExitCode}' is non zero"));
             }
 
@@ -187,13 +189,13 @@ public class DebianSourcePackageBuilder
         {
             return new Result().WithAnnotation(
                 new DpkgBuildPackageFailed(
-                    reason: $"Unexpected exception '{exception.GetType().FullName}'. {exception.Message}", 
-                    buildTarget: buildTarget, 
-                    location: new Location { ResourceLocator = sourceTreeDirectory.FullName }, 
+                    reason: $"Unexpected exception '{exception.GetType().FullName}'. {exception.Message}",
+                    buildTarget: buildTarget,
+                    location: new Location { ResourceLocator = sourceTreeDirectory.FullName },
                     innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception))));
         }
     }
-    
+
     private async Task<Result> RecursivelyCopyMatchingFilesAsync(
         DirectoryInfo sourceDirectory,
         DirectoryInfo destinationDirectory,
@@ -224,15 +226,15 @@ public class DebianSourcePackageBuilder
             })
             .ConfigureAwait(false);
     }
-    
+
     private Result CreateDestinationDirectory(DirectoryInfo destinationDirectory, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested) return new OperationCanceled();
-        
+
         if (destinationDirectory.Exists)
         {
             Result result = new OutputDirectoryAlreadyExists(destinationDirectory);
-            
+
             if (destinationDirectory.EnumerateFiles().Any() || destinationDirectory.EnumerateDirectories().Any())
             {
                 result = result.WithAnnotation(new OutputDirectoryContainsFiles(destinationDirectory));
@@ -240,7 +242,7 @@ public class DebianSourcePackageBuilder
 
             return result;
         }
-        
+
         try
         {
             destinationDirectory.Create();
@@ -251,13 +253,13 @@ public class DebianSourcePackageBuilder
             return new CreatingOutputDirectoryFailed(destinationDirectory, exception);
         }
     }
-    
-    private Result<ImmutableDictionary<string, FileInfo>> IndexSourceFiles(
-        DirectoryInfo sourceDirectory, 
+
+    private Result<ImmutableDictionary<string, FlamencoFileInfo>> IndexSourceFiles(
+        DirectoryInfo sourceDirectory,
         CancellationToken cancellationToken = default)
     {
         var result = new Result();
-        var destinationFiles = new Dictionary<string, (FileInfo Info, int BuildTargetSpecificity)>();
+        var destinationFiles = new Dictionary<string, (FlamencoFileInfo Info, int BuildTargetSpecificity)>();
 
         foreach (var file in sourceDirectory.EnumerateFiles())
         {
@@ -274,18 +276,22 @@ public class DebianSourcePackageBuilder
                     {
                         if (fileContext.BuildTargetSpecificity > otherFile.BuildTargetSpecificity)
                         {
-                            destinationFiles[fileContext.FileName] = (file, fileContext.BuildTargetSpecificity);
+                            destinationFiles[fileContext.FileName] = (
+                                new FlamencoFileInfo(fileContext.FlamencoFile, file),
+                                fileContext.BuildTargetSpecificity);
                         }
                         else if (fileContext.BuildTargetSpecificity == otherFile.BuildTargetSpecificity)
                         {
                             return new ConflictingBuildTargetSpecificity(
                                 conflictingFilePath1: file.FullName,
-                                conflictingFilePath2: otherFile.Info.FullName);
+                                conflictingFilePath2: otherFile.Info.FileInfo.FullName);
                         }
                     }
                     else
                     {
-                        destinationFiles[fileContext.FileName] = (file, fileContext.BuildTargetSpecificity);
+                        destinationFiles[fileContext.FileName] = (
+                            new FlamencoFileInfo(fileContext.FlamencoFile, file),
+                            fileContext.BuildTargetSpecificity);
                     }
 
                     return Result.Success;
@@ -293,38 +299,39 @@ public class DebianSourcePackageBuilder
             );
         }
 
-        return result.Then<ImmutableDictionary<string, FileInfo>>(
+        return result.Then<ImmutableDictionary<string, FlamencoFileInfo>>(
             () => destinationFiles.ToImmutableDictionary(
                 keySelector: e => e.Key,
                 elementSelector: e => e.Value.Info));
     }
-    
-    private Result<(string FileName, int BuildTargetSpecificity)> AnalyzeFileExtension(FileInfo file)
+
+    private Result<(string FileName, bool FlamencoFile, int BuildTargetSpecificity)> AnalyzeFileExtension(FileInfo file)
     {
         var result = new Result();
-        
+
         string[] fileExtensions = file.Name.Split('.');
         // Remember, that fileExtensions[0] is just the file name!
 
-        if (fileExtensions.Length < 2) 
+        if (fileExtensions.Length < 2)
         {
-            return result.WithValue((file.Name, BuildTargetSpecificity: 0));    
+            return result.WithValue((file.Name, FlamencoFile: false, BuildTargetSpecificity: 0));
         }
 
+        bool flamencoFile = false;
         bool matchesTarget = true;
         bool packageNameIsDefined = false;
         bool seriesNameIsDefined = false;
-        
+
         string extensionName;
         string[] extensionNames;
         int totalExtensionLength = 0;
-        
+
         if (fileExtensions.Length >= 2)
         {
             extensionName = fileExtensions[^1];
             extensionNames = extensionName.Split(',');
             totalExtensionLength = extensionName.Length + 1;
-            
+
             if (SourceDirectory.BuildableTargets.PackageNames.Any(extensionNames.Contains))
             {
                 packageNameIsDefined = true;
@@ -337,12 +344,13 @@ public class DebianSourcePackageBuilder
             }
             else
             {
-                return result.WithValue((file.Name, BuildTargetSpecificity: 0));
+                flamencoFile = file.Name.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
+                return result.WithValue((file.Name, flamencoFile, BuildTargetSpecificity: 0));
             }
         }
 
         int buildTargetSpecificity;
-        
+
         if (fileExtensions.Length >= 3)
         {
             extensionName = fileExtensions[^2];
@@ -367,7 +375,7 @@ public class DebianSourcePackageBuilder
                 }
 
                 result = result.WithAnnotation(new NonStandardFileExtensionFormat(file.FullName));
-                
+
                 seriesNameIsDefined = true;
                 matchesTarget = matchesTarget && extensionNames.Contains(BuildTarget.SeriesName);
                 totalExtensionLength += extensionName.Length + 1;
@@ -376,6 +384,13 @@ public class DebianSourcePackageBuilder
 
         string fileName = file.Name.Substring(startIndex: 0, length: file.Name.Length - totalExtensionLength);
 
+        flamencoFile = fileName.Equals(FlamencoFileName, StringComparison.CurrentCultureIgnoreCase);
+
+        // A specificity score that determines how specific a file is to a source package or series.
+        // A specificity of -1 means that the file is not specific to current build target.
+        // A specificity of 0 means that the file is not specific to a source package or series.
+        // A specificity of 1 means that the file is specific to either a source package or a series.
+        // A specificity of 2 means that the file is specific to both a source package and a series.
         if (!matchesTarget)
         {
             buildTargetSpecificity = -1;
@@ -388,18 +403,18 @@ public class DebianSourcePackageBuilder
         {
             buildTargetSpecificity = 1;
         }
-        
-        return result.WithValue((fileName, buildTargetSpecificity));
+
+        return result.WithValue((fileName, flamencoFile, buildTargetSpecificity));
     }
 
     private async Task<Result> CopySourceFilesToDestinationDirectoryAsync(
         DirectoryInfo sourceDirectory,
-        ImmutableDictionary<string, FileInfo> sourceFileIndex,
+        ImmutableDictionary<string, FlamencoFileInfo> sourceFileIndex,
         DirectoryInfo destinationDirectory,
         CancellationToken cancellationToken = default)
     {
         var result = Result.Success;
-        
+
         if (IsPatchesDirectory(sourceDirectory))
         {
             if (!sourceFileIndex.TryGetValue("series", out var seriesFile))
@@ -408,23 +423,23 @@ public class DebianSourcePackageBuilder
             }
 
             result = result.Merge(CopyFile(
-                sourceFile: seriesFile, 
-                destinationDirectory: destinationDirectory, 
+                sourceFile: seriesFile.FileInfo,
+                destinationDirectory: destinationDirectory,
                 fileName: "series"));
 
             if (result.IsFailure) return result;
 
             StreamReader seriesFileTextReader;
-            
+
             try
             {
-                seriesFileTextReader = seriesFile.OpenText();
+                seriesFileTextReader = seriesFile.FileInfo.OpenText();
             }
             catch (Exception exception)
             {
                 return result.WithAnnotation(new ReadingPatchesSeriesFileFailed(
-                    message: $"Opening the patches/series file '{seriesFile.FullName}' failed",
-                    location: new Location { ResourceLocator = seriesFile.FullName },
+                    message: $"Opening the patches/series file '{seriesFile.FileInfo.FullName}' failed",
+                    location: new Location { ResourceLocator = seriesFile.FileInfo.FullName },
                     exception: exception));
             }
 
@@ -448,15 +463,15 @@ public class DebianSourcePackageBuilder
                     catch (Exception exception)
                     {
                         return result.WithAnnotation(new ReadingPatchesSeriesFileFailed(
-                            message: $"Reading from the patches/series file '{seriesFile.FullName}' failed",
+                            message: $"Reading from the patches/series file '{seriesFile.FileInfo.FullName}' failed",
                             location: new Location
                             {
-                                ResourceLocator = seriesFile.FullName, 
+                                ResourceLocator = seriesFile.FileInfo.FullName,
                                 TextSpan = new LinePositionSpan(new LinePosition(lineNumber))
                             },
                             exception: exception));
                     }
-                    
+
                     if (line == null) return result;
                     if (string.IsNullOrWhiteSpace(line) || line.StartsWith('#')) continue;
 
@@ -465,12 +480,13 @@ public class DebianSourcePackageBuilder
                     // TODO: handle patches in subdirectories
                     if (!sourceFileIndex.TryGetValue(patchFilePath, out var patchFile))
                     {
-                        return result.WithAnnotation(new CouldNotFindPatchFile(seriesFile, lineNumber, patchFilePath));
+                        return result.WithAnnotation(new CouldNotFindPatchFile(seriesFile.FileInfo, lineNumber,
+                            patchFilePath));
                     }
 
                     result = result.Merge(CopyFile(
-                        sourceFile: patchFile, 
-                        destinationDirectory: destinationDirectory, 
+                        sourceFile: patchFile.FileInfo,
+                        destinationDirectory: destinationDirectory,
                         fileName: patchFilePath));
                 }
             }
@@ -481,14 +497,45 @@ public class DebianSourcePackageBuilder
             {
                 if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
 
-                result = result.Merge(CopyFile(fileInfo, destinationDirectory, fileName));
-                if (result.IsFailure) return result;
-            }  
+                if (fileInfo.FlamencoFile)
+                {
+                    result = result.Merge(await HandleFlamencoFile(fileInfo, destinationDirectory, cancellationToken));
+                }
+                else
+                {
+                    result = result.Merge(CopyFile(fileInfo.FileInfo, destinationDirectory, fileName));
+                                    if (result.IsFailure) return result;
+                }
+            }
         }
-        
+
         return result;
     }
-    
+
+    private async Task<Result> HandleFlamencoFile(FlamencoFileInfo fileInfo, DirectoryInfo destinationDirectory,
+        CancellationToken cancellationToken)
+    {
+        var result = Result.Success;
+
+        var jsonNode = JsonNode.Parse(await File.ReadAllTextAsync(fileInfo.FileInfo.FullName, cancellationToken));
+
+        var type = jsonNode?["type"]?.GetValue<string>();
+
+        switch (type)
+        {
+            case "external_source":
+                var externalSource = ExternalSources.ExternalSourceBase.Create(fileInfo.FileInfo);
+                await externalSource.Download(destinationDirectory.FullName, cancellationToken);
+                break;
+            default:
+                return result.WithAnnotation(new InvalidFlamencoFileType(
+                    filePath: fileInfo.FileInfo.FullName,
+                    type: type));
+        }
+
+        return result;
+    }
+
     private bool IsPatchesDirectory(DirectoryInfo directory)
     {
         var relativePath = Path.GetRelativePath(
@@ -501,7 +548,7 @@ public class DebianSourcePackageBuilder
     private Result CopyFile(FileInfo sourceFile, DirectoryInfo destinationDirectory, string fileName)
     {
         var destinationPath = Path.Combine(destinationDirectory.FullName, fileName);
-                
+
         try
         {
             sourceFile.CopyTo(destinationPath);
@@ -515,7 +562,7 @@ public class DebianSourcePackageBuilder
                 exception);
         }
     }
-    
+
     public class ConflictingBuildTargetSpecificity(
         string conflictingFilePath1,
         string conflictingFilePath2)
@@ -527,7 +574,7 @@ public class DebianSourcePackageBuilder
             locations: ImmutableList.Create(
                 new Location { ResourceLocator = conflictingFilePath1 },
                 new Location { ResourceLocator = conflictingFilePath2 })) {}
-    
+
     public class OutputDirectoryAlreadyExists(
         DirectoryInfo outputDirectory)
         : AnnotationBase(
@@ -537,7 +584,7 @@ public class DebianSourcePackageBuilder
             severity: AnnotationSeverity.Warning,
             warningLevel: WarningLevels.MinorWarning,
             locations: ImmutableList.Create(new Location { ResourceLocator = outputDirectory.FullName })) {}
-        
+
     public class OutputDirectoryContainsFiles(
         DirectoryInfo outputDirectory)
         : ErrorBase(
@@ -545,7 +592,7 @@ public class DebianSourcePackageBuilder
             title: "Output directory contains files",
             message: $"Output directory '{outputDirectory.FullName}' already contains files",
             locations: ImmutableList.Create(new Location { ResourceLocator = outputDirectory.FullName })) {}
-    
+
     public class CreatingOutputDirectoryFailed(
         DirectoryInfo outputDirectory,
         Exception exception)
@@ -555,7 +602,7 @@ public class DebianSourcePackageBuilder
             message: $"An unexpected error occured while creating the output directory '{outputDirectory.FullName}'",
             locations: ImmutableList.Create(new Location { ResourceLocator = outputDirectory.FullName }),
             innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception))) {}
-    
+
     public class CreatingOutputFileFailed(
         string sourceFilePath,
         string outputFilePath,
@@ -568,7 +615,7 @@ public class DebianSourcePackageBuilder
             innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)),
             metadata: ImmutableDictionary<string, object?>.Empty
                 .Add(key: "SourceFile", value: sourceFilePath)) {}
-    
+
     public class ConflictingPackageNameFileExtensions(
         string sourceFilePath)
         : ErrorBase(
@@ -576,7 +623,7 @@ public class DebianSourcePackageBuilder
             title: "Conflicting package name file extensions",
             message: $"The file extensions of '{sourceFilePath}' specifies two package names",
             locations: ImmutableList.Create(new Location { ResourceLocator = sourceFilePath })) {}
-    
+
     public class ConflictingSeriesNameFileExtensions(
         string sourceFilePath)
         : ErrorBase(
@@ -584,7 +631,7 @@ public class DebianSourcePackageBuilder
             title: "Conflicting package name file extensions",
             message: $"The file extensions of '{sourceFilePath}' specifies two series names",
             locations: ImmutableList.Create(new Location { ResourceLocator = sourceFilePath })) {}
-    
+
     public class NonStandardFileExtensionFormat(
         string sourceFilePath)
         : AnnotationBase(
@@ -595,7 +642,7 @@ public class DebianSourcePackageBuilder
             severity: AnnotationSeverity.Warning,
             warningLevel: WarningLevels.MinorWarning,
             locations: ImmutableList.Create(new Location { ResourceLocator = sourceFilePath })) {}
-    
+
     public class ChangelogFileNameAndContentMismatch(
         string message,
         Location location)
@@ -606,7 +653,7 @@ public class DebianSourcePackageBuilder
             severity: AnnotationSeverity.Warning,
             warningLevel: WarningLevels.SevereWarning,
             locations: ImmutableList.Create(location)) {}
-    
+
     public class OrigTarballNotFound(
         BuildTarget buildTarget,
         Location location)
@@ -615,7 +662,7 @@ public class DebianSourcePackageBuilder
             title: "Orig tarball not found",
             message: $"Orig tarball for packaging target {buildTarget} could not be found",
             locations: ImmutableList.Create(location)) {}
-    
+
     public class DpkgBuildPackageFailed(
         BuildTarget buildTarget,
         Location location,
@@ -627,7 +674,7 @@ public class DebianSourcePackageBuilder
             message: $"dpkg-buildpackage failed for target {buildTarget}. {reason}",
             locations: ImmutableList.Create(location),
             innerAnnotations: innerAnnotations) {}
-    
+
     public class MultipleTargetDistributionsSpecified(
         BuildTarget buildTarget,
         ImmutableArray<DpkgSuite> distributions,
@@ -644,7 +691,7 @@ public class DebianSourcePackageBuilder
         public BuildTarget BuildTarget => FromMetadata<BuildTarget>(nameof(BuildTarget));
         public ImmutableArray<DpkgSuite> Distributions => FromMetadata<ImmutableArray<DpkgSuite>>(nameof(Distributions));
     }
-    
+
     public class CouldNotFindPatchesSeriesFile(
         BuildTarget buildTarget)
         : ErrorBase(
@@ -656,7 +703,7 @@ public class DebianSourcePackageBuilder
     {
         public BuildTarget BuildTarget => FromMetadata<BuildTarget>(nameof(BuildTarget));
     }
-    
+
     public class ReadingPatchesSeriesFileFailed(
         string message,
         Location location,
@@ -669,7 +716,7 @@ public class DebianSourcePackageBuilder
             innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)))
     {
     }
-    
+
     public class CouldNotFindPatchFile(
         FileInfo seriesFile,
         int seriesFileLineNumber,
@@ -681,17 +728,28 @@ public class DebianSourcePackageBuilder
             locations: ImmutableList.Create(
                 new Location
                 {
-                    ResourceLocator = seriesFile.FullName, 
+                    ResourceLocator = seriesFile.FullName,
                     TextSpan = new LinePositionSpan(new LinePosition(seriesFileLineNumber))
-                }, 
+                },
                 new Location
                 {
                     ResourceLocator = patchFilePath,
                 }))
     {
         public Location SeriesFileLocation => Locations[0];
-        
+
         public Location MissingPatchFileLocation => Locations[1];
-    } 
+    }
+
+    public class InvalidFlamencoFileType(
+        string filePath,
+        string? type)
+        : ErrorBase(
+            identifier: "FL0041",
+            title: "Invalid Flamenco file type",
+            message: $"The Flamenco file '{filePath}' has an invalid or unsupported type '{type ?? "null"}'",
+            locations: ImmutableList.Create(new Location { ResourceLocator = filePath }))
+    {
+    }
 }
 

--- a/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
+++ b/src/Flamenco.Packaging/DebianSourcePackageBuilder.cs
@@ -520,11 +520,11 @@ public class DebianSourcePackageBuilder
     {
         var result = Result.Success;
 
-        var jsonNode = default(JsonNode);
+        JsonNode? jsonNode;
 
         try
         {
-            JsonNode.Parse(await File.ReadAllTextAsync(fileInfo.FileInfo.FullName, cancellationToken));
+            jsonNode = JsonNode.Parse(await File.ReadAllTextAsync(fileInfo.FileInfo.FullName, cancellationToken));
         }
         catch (JsonException ex)
         {

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -7,7 +7,7 @@ public abstract class ExternalSourceBase
 {
     public abstract Task<Result> Download(string destinationDirectory, CancellationToken cancellationToken = default);
 
-    public static Result<ExternalSourceBase> Create(JsonNode externalSource)
+    public static Result<ExternalSourceBase> Parse(JsonNode externalSource)
     {
         var invalidFields = new Dictionary<string, object?>();
         var type = externalSource["sourceType"]?.GetValue<string>();

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -5,7 +5,8 @@ namespace Flamenco.Packaging.ExternalSources;
 
 public abstract class ExternalSourceBase
 {
-    public abstract Task<Result> Download(string destinationDirectory, CancellationToken cancellationToken = default);
+    public abstract Task<Result> Download(DirectoryInfo destinationDirectory, DirectoryInfo cacheDirectory,
+        CancellationToken cancellationToken = default);
 
     public static Result<ExternalSourceBase> Parse(JsonNode externalSource)
     {

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -23,11 +23,12 @@ public abstract class ExternalSourceBase
                 }
                 var commitish = externalSource["commitish"]?.GetValue<string>();
                 var postCloneCommands = externalSource["postClone"]?.AsArray().GetValues<string>();
+                var ignoredFiles = externalSource["ignoredFiles"]?.AsArray().GetValues<string>();
 
-                return invalidFields.Any()
+                return invalidFields.Count != 0
                     ? new InvalidGitDescriptorFile(invalidFields)
                     : new Result<ExternalSourceBase>(Result.Success,
-                        new GitExternalSource(repository!, commitish, postCloneCommands));
+                        new GitExternalSource(repository!, commitish, postCloneCommands, ignoredFiles));
             case null:
                 return new UnspecifiedExternalSourceType();
             default:

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -22,10 +22,12 @@ public abstract class ExternalSourceBase
                     invalidFields.Add("repository", "The 'repository' field is required for git external sources.");
                 }
                 var commitish = externalSource["commitish"]?.GetValue<string>();
+                var postCloneCommands = externalSource["postClone"]?.AsArray().GetValues<string>();
 
                 return invalidFields.Any()
                     ? new InvalidGitDescriptorFile(invalidFields)
-                    : new Result<ExternalSourceBase>(Result.Success, new GitExternalSource(repository!, commitish));
+                    : new Result<ExternalSourceBase>(Result.Success,
+                        new GitExternalSource(repository!, commitish, postCloneCommands));
             case null:
                 return new UnspecifiedExternalSourceType();
             default:

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -36,20 +36,20 @@ public abstract class ExternalSourceBase
     public class UnsupportedExternalSourceType(
         string sourceType)
         : ErrorBase(
-            identifier: "FL0042",
+            identifier: "FL0043",
             title: "Unsupported external source type.",
             message: $"The external source type '{sourceType}' is not supported.");
 
     public class UnspecifiedExternalSourceType()
         : ErrorBase(
-            identifier: "FL0043",
+            identifier: "FL0044",
             title: "Unspecified external source type.",
             message: "The external source type is not specified in the descriptor file.");
 
     public class InvalidGitDescriptorFile(
         Dictionary<string, object?> invalidFields)
         : ErrorBase(
-            identifier: "FL0044",
+            identifier: "FL0045",
             title: "Invalid git external source descriptor.",
             message: "The git external source descriptor file is invalid.",
             metadata: invalidFields.ToImmutableDictionary());

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Nodes;
+
+namespace Flamenco.Packaging.ExternalSources;
+
+public abstract class ExternalSourceBase
+{
+    public abstract Task Download(string destinationDirectory, CancellationToken cancellationToken = default);
+
+    public static ExternalSourceBase Create(FileInfo fileInfo)
+    {
+        if (!fileInfo.Exists)
+        {
+            throw new FileNotFoundException("Descriptor file not found.", fileInfo.FullName);
+        }
+
+        var jsonNode = JsonNode.Parse(File.ReadAllText(fileInfo.FullName));
+        var type = jsonNode?["sourceType"]?.GetValue<string>();
+
+        switch (type)
+        {
+            case "git":
+                var repository = jsonNode?["repository"]?.GetValue<string>();
+                var commitish = jsonNode?["commitish"]?.GetValue<string>();
+                return repository == null
+                    ? throw new InvalidDataException("Git external source descriptor must contain a 'repository' field.")
+                    : new GitExternalSource(repository, commitish);
+            default:
+                throw new NotSupportedException($"External source type '{type}' is not supported.");
+        }
+    }
+}

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -22,13 +22,14 @@ public abstract class ExternalSourceBase
                     invalidFields.Add("repository", "The 'repository' field is required for git external sources.");
                 }
                 var commitish = externalSource["commitish"]?.GetValue<string>();
+                var rootDirectory = externalSource["rootDirectory"]?.GetValue<string>();
                 var postCloneCommands = externalSource["postClone"]?.AsArray().GetValues<string>();
                 var ignoredFiles = externalSource["ignoredFiles"]?.AsArray().GetValues<string>();
 
                 return invalidFields.Count != 0
                     ? new InvalidGitDescriptorFile(invalidFields)
                     : new Result<ExternalSourceBase>(Result.Success,
-                        new GitExternalSource(repository!, commitish, postCloneCommands, ignoredFiles));
+                        new GitExternalSource(repository!, commitish, rootDirectory, postCloneCommands, ignoredFiles));
             case null:
                 return new UnspecifiedExternalSourceType();
             default:

--- a/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
+++ b/src/Flamenco.Packaging/ExternalSources/ExternalSourceBase.cs
@@ -1,31 +1,55 @@
+using System.Collections.Immutable;
 using System.Text.Json.Nodes;
 
 namespace Flamenco.Packaging.ExternalSources;
 
 public abstract class ExternalSourceBase
 {
-    public abstract Task Download(string destinationDirectory, CancellationToken cancellationToken = default);
+    public abstract Task<Result> Download(string destinationDirectory, CancellationToken cancellationToken = default);
 
-    public static ExternalSourceBase Create(FileInfo fileInfo)
+    public static Result<ExternalSourceBase> Create(JsonNode externalSource)
     {
-        if (!fileInfo.Exists)
-        {
-            throw new FileNotFoundException("Descriptor file not found.", fileInfo.FullName);
-        }
-
-        var jsonNode = JsonNode.Parse(File.ReadAllText(fileInfo.FullName));
-        var type = jsonNode?["sourceType"]?.GetValue<string>();
+        var invalidFields = new Dictionary<string, object?>();
+        var type = externalSource["sourceType"]?.GetValue<string>();
 
         switch (type)
         {
             case "git":
-                var repository = jsonNode?["repository"]?.GetValue<string>();
-                var commitish = jsonNode?["commitish"]?.GetValue<string>();
-                return repository == null
-                    ? throw new InvalidDataException("Git external source descriptor must contain a 'repository' field.")
-                    : new GitExternalSource(repository, commitish);
+                var repository = externalSource["repository"]?.GetValue<string>();
+                if (repository is null)
+                {
+                    invalidFields.Add("repository", "The 'repository' field is required for git external sources.");
+                }
+                var commitish = externalSource["commitish"]?.GetValue<string>();
+
+                return invalidFields.Any()
+                    ? new InvalidGitDescriptorFile(invalidFields)
+                    : new Result<ExternalSourceBase>(Result.Success, new GitExternalSource(repository!, commitish));
+            case null:
+                return new UnspecifiedExternalSourceType();
             default:
-                throw new NotSupportedException($"External source type '{type}' is not supported.");
+                return new UnsupportedExternalSourceType(type);
         }
     }
+
+    public class UnsupportedExternalSourceType(
+        string sourceType)
+        : ErrorBase(
+            identifier: "FL0042",
+            title: "Unsupported external source type.",
+            message: $"The external source type '{sourceType}' is not supported.");
+
+    public class UnspecifiedExternalSourceType()
+        : ErrorBase(
+            identifier: "FL0043",
+            title: "Unspecified external source type.",
+            message: "The external source type is not specified in the descriptor file.");
+
+    public class InvalidGitDescriptorFile(
+        Dictionary<string, object?> invalidFields)
+        : ErrorBase(
+            identifier: "FL0044",
+            title: "Invalid git external source descriptor.",
+            message: "The git external source descriptor file is invalid.",
+            metadata: invalidFields.ToImmutableDictionary());
 }

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using LibGit2Sharp;
 
 namespace Flamenco.Packaging.ExternalSources;
@@ -13,13 +14,43 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
 
         if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
 
-        await Task.Run(() => LibGit2Sharp.Repository.Clone(Repository, destinationDirectory, new CloneOptions
+        try
         {
-            BranchName = Commitish
-        }), cancellationToken);
+            await Task.Run(() =>
+            {
+                LibGit2Sharp.Repository.Clone(Repository, destinationDirectory);
 
-        Directory.Delete(Path.Join(destinationDirectory, ".git"), recursive: true);
+                if (string.IsNullOrEmpty(Commitish)) return;
+
+                using var repo = new Repository(destinationDirectory);
+                Commands.Checkout(repo, Commitish);
+            }, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return result.WithAnnotation(new OperationCanceled());
+        }
+        catch (Exception ex)
+        {
+            return new GitCloneFailed(Repository, Commitish, ex);
+        }
+
+        var gitDir = Path.Join(destinationDirectory, ".git");
+        if (Directory.Exists(gitDir))
+        {
+            Directory.Delete(Path.Join(destinationDirectory, ".git"), recursive: true);
+        }
 
         return result;
     }
+
+    public class GitCloneFailed(
+        string repository,
+        string? commitish,
+        Exception exception)
+        : ErrorBase(
+            identifier: "FL0050",
+            title: "Git clone failed.",
+            message: $"Failed to clone the git repository '{repository}' at '{commitish ?? "default branch"}'",
+            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)));
 }

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -127,25 +127,31 @@ public class GitExternalSource(
 
         foreach (var command in PostCloneCommands)
         {
-            var process = new Process
+            using var process = new Process();
+
+            process.StartInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "/usr/bin/env",
-                    ArgumentList = { "sh", "-c", command },
-                    WorkingDirectory = workingDirectory.FullName,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = "/usr/bin/env",
+                ArgumentList = { "sh", "-c", command },
+                WorkingDirectory = workingDirectory.FullName,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
 
-            process.Start();
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-
-            if (process.ExitCode != 0)
+            int? exitCode = null;
+            if (process.Start())
             {
-                return result.Merge(new Result().WithAnnotation(new PostCloneCommandFailed(command, process.ExitCode)));
+                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+                if (process.ExitCode == 0)
+                {
+                    continue;
+                }
+
+                exitCode = process.ExitCode;
             }
+
+            return result.Merge(new Result().WithAnnotation(new PostCloneCommandFailed(command, exitCode)));
         }
 
         return result;
@@ -238,11 +244,13 @@ public class GitExternalSource(
 
     public class PostCloneCommandFailed(
     string command,
-    int exitCode)
+    int? exitCode)
     : ErrorBase(
         identifier: "FL0053",
         title: "Post-clone command failed.",
-        message: $"The post-clone command '{command}' failed with exit code {exitCode}.");
+        message: exitCode.HasValue
+            ? $"The post-clone command '{command}' failed with exit code {exitCode}."
+            : $"The post-clone command '{command} could not run.");
 
     public class DeletionOfIgnoredFileFailed(
         string filePath,

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -8,7 +8,8 @@ namespace Flamenco.Packaging.ExternalSources;
 public class GitExternalSource(
     string repository,
     string? commitish = null,
-    IEnumerable<string>? postCloneCommands = null) : ExternalSourceBase
+    IEnumerable<string>? postCloneCommands = null,
+    IEnumerable<string>? ignoredFiles = null) : ExternalSourceBase
 {
     // We want to clone a repository only once and copy the local clone of the repo to every package x series destination.
     // For that reason, we use a semaphore for each repository to ensure that only one clone operation happens at a time.
@@ -19,6 +20,7 @@ public class GitExternalSource(
     public string Repository { get; } = repository;
     public string? Commitish { get; } = commitish;
     public IReadOnlyList<string> PostCloneCommands { get; } = (postCloneCommands ?? []).ToList();
+    public IReadOnlyList<string> IgnoredFiles { get; } = (ignoredFiles ?? []).ToList();
 
     public override async Task<Result> Download(DirectoryInfo destinationDirectory, DirectoryInfo cacheDirectory,
         CancellationToken cancellationToken = default)
@@ -64,6 +66,12 @@ public class GitExternalSource(
                 if (postCloneResult.IsFailure)
                 {
                     return postCloneResult;
+                }
+
+                var deletionResult = DeleteIgnoredFiles(repositoryCacheDir, cancellationToken);
+                if (deletionResult.IsFailure)
+                {
+                    return deletionResult;
                 }
 
                 var gitDir = Path.Join(repositoryCacheDir.FullName, ".git");
@@ -125,6 +133,32 @@ public class GitExternalSource(
         return result;
     }
 
+    private Result DeleteIgnoredFiles(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        var result = new Result();
+
+        foreach (var ignoredFile in IgnoredFiles)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var filePath = Path.Join(workingDirectory.FullName, ignoredFile);
+
+            // If a file does not exist, we don't want to treat it as an error, similar to how '.gitignore' works.
+            if (!File.Exists(filePath)) continue;
+
+            try
+            {
+                File.Delete(filePath);
+            }
+            catch (Exception ex)
+            {
+                return result.Merge(new Result().WithAnnotation(
+                    new DeletionOfIgnoredFileFailed(filePath, ex)));
+            }
+        }
+
+        return result;
+    }
+
     private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination, CancellationToken cancellationToken)
     {
         foreach (var file in source.EnumerateFiles("*", SearchOption.AllDirectories))
@@ -174,4 +208,15 @@ public class GitExternalSource(
         identifier: "FL0052",
         title: "Post-clone command failed.",
         message: $"The post-clone command '{command}' failed with exit code {exitCode}.");
+
+    public class DeletionOfIgnoredFileFailed(
+        string filePath,
+        Exception exception)
+        : ErrorBase(
+            identifier: "FL0053",
+            title: "Deletion of ignored file failed.",
+            message: $"Failed to delete the ignored file '{filePath}'.",
+            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)),
+            locations: ImmutableList.Create(
+                new Location { ResourceLocator = filePath }));
 }

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -8,6 +8,7 @@ namespace Flamenco.Packaging.ExternalSources;
 public class GitExternalSource(
     string repository,
     string? commitish = null,
+    string? rootDirectory = null,
     IEnumerable<string>? postCloneCommands = null,
     IEnumerable<string>? ignoredFiles = null) : ExternalSourceBase
 {
@@ -19,6 +20,7 @@ public class GitExternalSource(
 
     public string Repository { get; } = repository;
     public string? Commitish { get; } = commitish;
+    public string? RootDirectory { get; set; } = rootDirectory;
     public IReadOnlyList<string> PostCloneCommands { get; } = (postCloneCommands ?? []).ToList();
     public IReadOnlyList<string> IgnoredFiles { get; } = (ignoredFiles ?? []).ToList();
 
@@ -88,7 +90,20 @@ public class GitExternalSource(
 
         try
         {
-            await Task.Run(() => CopyDirectory(repositoryCacheDir, destinationDirectory, cancellationToken),
+            var sourceDirectory = repositoryCacheDir;
+            if (!string.IsNullOrWhiteSpace(RootDirectory))
+            {
+                var newSourceDirectory = Path.Join(repositoryCacheDir.FullName, RootDirectory);
+
+                if (!Directory.Exists(newSourceDirectory))
+                {
+                    return result.WithAnnotation(new RootDirectoryNotFound(RootDirectory!));
+                }
+
+                sourceDirectory = new DirectoryInfo(newSourceDirectory);
+            }
+
+            await Task.Run(() => CopyDirectory(sourceDirectory, destinationDirectory, cancellationToken),
                 cancellationToken);
         }
         catch (OperationCanceledException)
@@ -211,11 +226,18 @@ public class GitExternalSource(
                 new Location { ResourceLocator = sourcePath },
                 new Location { ResourceLocator = destinationPath }));
 
+    public class RootDirectoryNotFound(
+        string rootDirectory)
+        : ErrorBase(
+            identifier: "FL0052",
+            title: "Root directory not found.",
+            message: $"The specified root directory '{rootDirectory}' was not found in the cloned repository.");
+
     public class PostCloneCommandFailed(
     string command,
     int exitCode)
     : ErrorBase(
-        identifier: "FL0052",
+        identifier: "FL0053",
         title: "Post-clone command failed.",
         message: $"The post-clone command '{command}' failed with exit code {exitCode}.");
 
@@ -223,7 +245,7 @@ public class GitExternalSource(
         string filePath,
         Exception exception)
         : ErrorBase(
-            identifier: "FL0053",
+            identifier: "FL0054",
             title: "Deletion of ignored file failed.",
             message: $"Failed to delete the ignored file '{filePath}'.",
             innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)),

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using LibGit2Sharp;
 
@@ -5,43 +6,87 @@ namespace Flamenco.Packaging.ExternalSources;
 
 public class GitExternalSource(string repository, string? commitish = null) : ExternalSourceBase
 {
+    // We want to clone a repository only once and copy the local clone of the repo to every package x series destination.
+    // For that reason, we use a semaphore for each repository to ensure that only one clone operation happens at a time.
+    // All subsequent operations will be a directory copy.
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> RepositorySemaphores =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public string Repository { get; } = repository;
     public string? Commitish { get; } = commitish;
 
-    public override async Task<Result> Download(string destinationDirectory, CancellationToken cancellationToken = default)
+    public override async Task<Result> Download(DirectoryInfo destinationDirectory, DirectoryInfo cacheDirectory,
+        CancellationToken cancellationToken = default)
     {
         var result = Result.Success;
 
         if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
 
+        var repositoryCacheDir =
+            new DirectoryInfo(Path.Join(cacheDirectory.FullName, "git", destinationDirectory.Name));
+
+        var semaphore = RepositorySemaphores.GetOrAdd(repositoryCacheDir.FullName,
+            _ => new SemaphoreSlim(initialCount: 1, maxCount: 1));
+
+        await semaphore.WaitAsync(cancellationToken);
         try
         {
-            await Task.Run(() =>
+            if (!repositoryCacheDir.Exists)
             {
-                LibGit2Sharp.Repository.Clone(Repository, destinationDirectory);
+                repositoryCacheDir.Create();
+                try
+                {
+                    await Task.Run(() =>
+                    {
+                        LibGit2Sharp.Repository.Clone(Repository, repositoryCacheDir.FullName);
 
-                if (string.IsNullOrEmpty(Commitish)) return;
+                        if (string.IsNullOrEmpty(Commitish)) return;
 
-                using var repo = new Repository(destinationDirectory);
-                Commands.Checkout(repo, Commitish);
-            }, cancellationToken);
+                        using var repo = new Repository(repositoryCacheDir.FullName);
+                        Commands.Checkout(repo, Commitish);
+                    }, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    return result.WithAnnotation(new OperationCanceled());
+                }
+                catch (Exception ex)
+                {
+                    return new GitCloneFailed(Repository, Commitish, ex);
+                }
+
+                var gitDir = Path.Join(repositoryCacheDir.FullName, ".git");
+                if (Directory.Exists(gitDir))
+                {
+                    Directory.Delete(Path.Join(repositoryCacheDir.FullName, ".git"), recursive: true);
+                }
+            }
         }
-        catch (OperationCanceledException)
+        finally
         {
-            return result.WithAnnotation(new OperationCanceled());
-        }
-        catch (Exception ex)
-        {
-            return new GitCloneFailed(Repository, Commitish, ex);
+            semaphore.Release();
         }
 
-        var gitDir = Path.Join(destinationDirectory, ".git");
-        if (Directory.Exists(gitDir))
-        {
-            Directory.Delete(Path.Join(destinationDirectory, ".git"), recursive: true);
-        }
+        await Task.Run(() => CopyDirectory(repositoryCacheDir, destinationDirectory), cancellationToken);
 
         return result;
+    }
+
+    private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination)
+    {
+        foreach (var file in source.EnumerateFiles("*", SearchOption.AllDirectories))
+        {
+            var relativePath = Path.GetRelativePath(source.FullName, file.FullName);
+            var targetPath = Path.Join(destination.FullName, relativePath);
+
+            var targetDir = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrEmpty(targetDir))
+            {
+                Directory.CreateDirectory(targetDir);
+            }
+
+            file.CopyTo(targetPath, overwrite: true);
+        }
     }
 
     public class GitCloneFailed(

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -58,7 +58,7 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
                 var gitDir = Path.Join(repositoryCacheDir.FullName, ".git");
                 if (Directory.Exists(gitDir))
                 {
-                    Directory.Delete(Path.Join(repositoryCacheDir.FullName, ".git"), recursive: true);
+                    Directory.Delete(gitDir, recursive: true);
                 }
             }
         }
@@ -67,15 +67,29 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
             semaphore.Release();
         }
 
-        await Task.Run(() => CopyDirectory(repositoryCacheDir, destinationDirectory), cancellationToken);
+        try
+        {
+            await Task.Run(() => CopyDirectory(repositoryCacheDir, destinationDirectory, cancellationToken),
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return result.WithAnnotation(new OperationCanceled());
+        }
+        catch (Exception ex)
+        {
+            return new RepositoryCopyFromCacheFailed(repositoryCacheDir.FullName, destinationDirectory.FullName, ex);
+        }
 
         return result;
     }
 
-    private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination)
+    private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination, CancellationToken cancellationToken)
     {
         foreach (var file in source.EnumerateFiles("*", SearchOption.AllDirectories))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var relativePath = Path.GetRelativePath(source.FullName, file.FullName);
             var targetPath = Path.Join(destination.FullName, relativePath);
 
@@ -98,4 +112,17 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
             title: "Git clone failed.",
             message: $"Failed to clone the git repository '{repository}' at '{commitish ?? "default branch"}'",
             innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)));
+
+    public class RepositoryCopyFromCacheFailed(
+        string sourcePath,
+        string destinationPath,
+        Exception exception)
+        : ErrorBase(
+            identifier: "FL0051",
+            title: "Repository copy from cache failed.",
+            message: $"Failed to copy the git repository '{sourcePath}' from cache to '{destinationPath}'.",
+            innerAnnotations: ImmutableList.Create<IAnnotation>(new ExceptionalAnnotation(exception)),
+            locations: ImmutableList.Create(
+                new Location { ResourceLocator = sourcePath },
+                new Location { ResourceLocator = destinationPath }));
 }

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -140,19 +140,29 @@ public class GitExternalSource(
         foreach (var ignoredFile in IgnoredFiles)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var filePath = Path.Join(workingDirectory.FullName, ignoredFile);
+            var path = Path.Join(workingDirectory.FullName, ignoredFile);
 
-            // If a file does not exist, we don't want to treat it as an error, similar to how '.gitignore' works.
-            if (!File.Exists(filePath)) continue;
+            // If neither a file nor directory exists, we don't want to treat it as an error, similar to how '.gitignore' works.
+            var isFile = File.Exists(path);
+            var isDirectory = Directory.Exists(path);
+
+            if (!isFile && !isDirectory) continue;
 
             try
             {
-                File.Delete(filePath);
+                if (isDirectory)
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+                else
+                {
+                    File.Delete(path);
+                }
             }
             catch (Exception ex)
             {
                 return result.Merge(new Result().WithAnnotation(
-                    new DeletionOfIgnoredFileFailed(filePath, ex)));
+                    new DeletionOfIgnoredFileFailed(path, ex)));
             }
         }
 

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -120,8 +120,6 @@ public class GitExternalSource(
             {
                 return result.Merge(new Result().WithAnnotation(new PostCloneCommandFailed(command, process.ExitCode)));
             }
-
-            result.Merge(Result.Success);
         }
 
         return result;

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -31,8 +31,11 @@ public class GitExternalSource(
 
         if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
 
+        // We use both the repository URL and the commitish to create a unique cache directory for each specific state
+        // of the repository.
+        var repoCacheDirName = $"{destinationDirectory.Name}@{Commitish ?? "default"}";
         var repositoryCacheDir =
-            new DirectoryInfo(Path.Join(cacheDirectory.FullName, "git", destinationDirectory.Name));
+            new DirectoryInfo(Path.Join(cacheDirectory.FullName, "git", repoCacheDirName));
 
         var semaphore = RepositorySemaphores.GetOrAdd(repositoryCacheDir.FullName,
             _ => new SemaphoreSlim(initialCount: 1, maxCount: 1));

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -1,10 +1,14 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using LibGit2Sharp;
 
 namespace Flamenco.Packaging.ExternalSources;
 
-public class GitExternalSource(string repository, string? commitish = null) : ExternalSourceBase
+public class GitExternalSource(
+    string repository,
+    string? commitish = null,
+    IEnumerable<string>? postCloneCommands = null) : ExternalSourceBase
 {
     // We want to clone a repository only once and copy the local clone of the repo to every package x series destination.
     // For that reason, we use a semaphore for each repository to ensure that only one clone operation happens at a time.
@@ -14,6 +18,7 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
 
     public string Repository { get; } = repository;
     public string? Commitish { get; } = commitish;
+    public IReadOnlyList<string> PostCloneCommands { get; } = (postCloneCommands ?? []).ToList();
 
     public override async Task<Result> Download(DirectoryInfo destinationDirectory, DirectoryInfo cacheDirectory,
         CancellationToken cancellationToken = default)
@@ -55,6 +60,12 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
                     return new GitCloneFailed(Repository, Commitish, ex);
                 }
 
+                var postCloneResult = await RunPostCloneCommands(repositoryCacheDir, cancellationToken);
+                if (postCloneResult.IsFailure)
+                {
+                    return postCloneResult;
+                }
+
                 var gitDir = Path.Join(repositoryCacheDir.FullName, ".git");
                 if (Directory.Exists(gitDir))
                 {
@@ -79,6 +90,39 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
         catch (Exception ex)
         {
             return new RepositoryCopyFromCacheFailed(repositoryCacheDir.FullName, destinationDirectory.FullName, ex);
+        }
+
+        return result;
+    }
+
+    private async Task<Result> RunPostCloneCommands(DirectoryInfo workingDirectory, CancellationToken cancellationToken)
+    {
+        var result = new Result();
+
+        foreach (var command in PostCloneCommands)
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo(
+                    fileName: "/usr/bin/env",
+                    arguments: command.Split(' ',
+                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                {
+                    WorkingDirectory = workingDirectory.FullName,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (process.ExitCode != 0)
+            {
+                return result.Merge(new Result().WithAnnotation(new PostCloneCommandFailed(command, process.ExitCode)));
+            }
+
+            result.Merge(Result.Success);
         }
 
         return result;
@@ -125,4 +169,12 @@ public class GitExternalSource(string repository, string? commitish = null) : Ex
             locations: ImmutableList.Create(
                 new Location { ResourceLocator = sourcePath },
                 new Location { ResourceLocator = destinationPath }));
+
+    public class PostCloneCommandFailed(
+    string command,
+    int exitCode)
+    : ErrorBase(
+        identifier: "FL0052",
+        title: "Post-clone command failed.",
+        message: $"The post-clone command '{command}' failed with exit code {exitCode}.");
 }

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -103,11 +103,10 @@ public class GitExternalSource(
         {
             var process = new Process
             {
-                StartInfo = new ProcessStartInfo(
-                    fileName: "/usr/bin/env",
-                    arguments: command.Split(' ',
-                        StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                StartInfo = new ProcessStartInfo
                 {
+                    FileName = "/usr/bin/env",
+                    ArgumentList = { "sh", "-c", command },
                     WorkingDirectory = workingDirectory.FullName,
                     UseShellExecute = false,
                     CreateNoWindow = true

--- a/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
+++ b/src/Flamenco.Packaging/ExternalSources/GitExternalSource.cs
@@ -1,0 +1,25 @@
+using LibGit2Sharp;
+
+namespace Flamenco.Packaging.ExternalSources;
+
+public class GitExternalSource(string repository, string? commitish = null) : ExternalSourceBase
+{
+    public string Repository { get; } = repository;
+    public string? Commitish { get; } = commitish;
+
+    public override async Task<Result> Download(string destinationDirectory, CancellationToken cancellationToken = default)
+    {
+        var result = Result.Success;
+
+        if (cancellationToken.IsCancellationRequested) return result.WithAnnotation(new OperationCanceled());
+
+        await Task.Run(() => LibGit2Sharp.Repository.Clone(Repository, destinationDirectory, new CloneOptions
+        {
+            BranchName = Commitish
+        }), cancellationToken);
+
+        Directory.Delete(Path.Join(destinationDirectory, ".git"), recursive: true);
+
+        return result;
+    }
+}

--- a/src/Flamenco.Packaging/Flamenco.Packaging.csproj
+++ b/src/Flamenco.Packaging/Flamenco.Packaging.csproj
@@ -5,4 +5,8 @@
     <ProjectReference Include="../Flamenco.Shared/Flamenco.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Flamenco.Packaging/FlamencoFileInfo.cs
+++ b/src/Flamenco.Packaging/FlamencoFileInfo.cs
@@ -1,0 +1,7 @@
+namespace Flamenco.Packaging;
+
+internal sealed class FlamencoFileInfo(bool flamencoFile, FileInfo fileInfo)
+{
+    public bool FlamencoFile { get; } = flamencoFile;
+    public FileInfo FileInfo { get; } = fileInfo;
+}

--- a/src/Flamenco.Packaging/FlamencoFileInfo.cs
+++ b/src/Flamenco.Packaging/FlamencoFileInfo.cs
@@ -1,7 +1,7 @@
 namespace Flamenco.Packaging;
 
-internal sealed class FlamencoFileInfo(bool flamencoFile, FileInfo fileInfo)
+internal sealed class FlamencoFileInfo(bool isFlamencoFile, FileInfo fileInfo)
 {
-    public bool FlamencoFile { get; } = flamencoFile;
+    public bool IsFlamencoFile { get; } = isFlamencoFile;
     public FileInfo FileInfo { get; } = fileInfo;
 }

--- a/src/Flamenco.Packaging/TarSystemCommand.cs
+++ b/src/Flamenco.Packaging/TarSystemCommand.cs
@@ -105,14 +105,17 @@ public class TarSystemCommand : ITarArchivingServiceProvider
     {
         var result = new Result();
         var tarProcessInfo = new ProcessStartInfo(
-            fileName: "/usr/bin/env", 
-            arguments: arguments.Prepend("tar"))
+            fileName: "/usr/bin/tar")
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+        foreach (var argument in arguments)
+        {
+            tarProcessInfo.ArgumentList.Add(argument);
+        }
         
         using var tarProcess = new Process();
         var standardOutput = new StringBuilder();


### PR DESCRIPTION
This PR supersedes #5.

This introduces the concept of a "Flamenco file", called `flamenco.json`. It will be handled just like any other file in terms of package and series specifiers, but, instead of being copied directly to the destination directory, it will be handled and acted upon according to its type.

The first type supported by this PR is `external_source`, which describes where to get the directory's content. As an example, this is what a Git external source descriptor would look like:

```JSON
//src/eng/test-runner/flamenco.json
{
    "type": "external_source",
    "sourceType": "git",
    "repository": "https://github.com/canonical/dotnet-test-runner",
    "commitish": "v1.2.0",
    "rootDirectory": "src/main",
    "postClone": [
        "make GIT_COMMIT_ID",
        "make GIT_TAG_VERSION"
    ],
    "ignoredFiles": [
        ".gitignore",
        ".github/workflows/build.yml"
    ]
}
```
Where:
- `rootDirectory` changes the directory to be copied to the destination.
- `postClone` specifies terminal commands to run after clone, before deleting the `.git` directory.
- `ignoredFiles` are files removed from the repository before copying it to the destination.

Note that, so far, only `git` is implemented.

There is an AI-generated documentation page on external sources available at [docs/external-sources.md](https://github.com/canonical/flamenco/blob/feat/external-sources-2/docs/external-sources.md).

Closes #3 